### PR TITLE
Corrección de tamaño de fuente en plantilla de relevamiento

### DIFF
--- a/Relevamiento inicial del equipo.tex
+++ b/Relevamiento inicial del equipo.tex
@@ -14,11 +14,12 @@
 
 \begin{tabular}{|c|}
     \hline
-        \LARGE \bfseries "TRABAJO POR EQUIPO 2015 -Equipo Nº''\\
+        {\LARGE {\bfseries "TRABAJO POR EQUIPO 2015 -Equipo Nº''}}
+        \\
     \hline
 \end{tabular}
 
-\Large {\bfseries ''Cátedra: PROYECTO FINAL (Integradora)''}
+{\Large {\bfseries ''Cátedra: PROYECTO FINAL (Integradora)''}}
 
 \begin{tabular}{|>{\raggedright\arraybackslash}m{7cm}|m{9cm}|}
     \hline


### PR DESCRIPTION
Los comandos ```\Large``` y ```\LARGE``` no estaban correctamente aislados, por lo que aumentaban el tamaño de fuente de todo el texto posterior a su declaración.